### PR TITLE
EBF: Set sticky bit for temporary directory.

### DIFF
--- a/src/engi_helpful_scripts/run.py
+++ b/src/engi_helpful_scripts/run.py
@@ -34,6 +34,8 @@ async def set_docker_tmp_volume(
     with tempfile.TemporaryDirectory(prefix=prefix) as tmpdir:
         # the volume name is the tmp dir basename
         tmpdir_p = Path(tmpdir)
+        # set temporary directory with sticky bit (i.e. /tmp)
+        os.chmod(tmpdir_p, 0o1777)
         # create the external volume
         await run(
             f"docker volume create --driver local -o o=bind -o type=none -o device='{tmpdir}' {tmpdir_p.name}"


### PR DESCRIPTION
Permissions on container match host directory permissions, need to set sticky but on temp dir.