### PR TITLE
Don't format lizard exclude options

### DIFF
--- a/src/engi_helpful_scripts/git.py
+++ b/src/engi_helpful_scripts/git.py
@@ -213,8 +213,9 @@ async def github_gist_delete(url):
 
 async def get_lizard_metrics(path, exclude=None):
     """run lizard to get the files, source lines of code and cyclomatic complexity of the code in path"""
-    exclude_opt = "" if exclude is None else f" --exclude '{path}/{exclude}'"
-    cmd_exit = await run(f"lizard {path} --csv --verbose{exclude_opt}")
+    exclude_opt = "" if exclude is None else exclude
+    cmd = f"lizard {path} --csv --verbose {exclude_opt}"
+    cmd_exit = await run(cmd)
     rows = list(csv.DictReader(StringIO(cmd_exit.stdout)))
     c = [int(r["CCN"]) for r in rows]
     return {


### PR DESCRIPTION
CLI analyses haven't been getting complete metrics incl files/dirs see [CLI issue](https://github.com/engi-network/cli/issues/19#issuecomment-1777539539)

Experimenting locally with [lizard](https://github.com/terryyin/lizard/issues) only setting explicit include and exclude options using the users' `.gitignore` produced the desired results. You can see some of the format lizard expects in the screenshot below

<img width="673" alt="lizard-include-patterns-results" src="https://github.com/engi-network/engi-helpful-scripts/assets/8270120/a27597d1-f823-4e05-9a13-993dbd40957f">

This `helpful-scripts` change supports the main CLI PR